### PR TITLE
Massive refactor into separate layout modules

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,17 +1,4 @@
 import './style.css'
 import { app } from './layouts/app'
 
-
-function moduleRender() {
-	const jsTarget = document.createElement('div')
-	jsTarget.classList.add('js-target')
-
-	// modules to load below
-	jsTarget.appendChild(app.layoutElement)
-	
-
-	return jsTarget
-}
-
-document.body.appendChild(moduleRender())
-app.addProjectTabListener()
+document.body.appendChild(app.layoutElement)

--- a/src/layouts/app.js
+++ b/src/layouts/app.js
@@ -1,24 +1,13 @@
-import { tasks } from "../modules/createTask"
-import { projects } from "../modules/createProject"
-import { utility as u } from "../modules/utilityFunctions"
+import { projects } from "../modules/createProject";
+import { projectLayout } from "./projects";
+import { taskLayout } from "./tasks";
 
-// conditionally render default projects
-if (projects.projectList.length === 0) {
-	projects.addProject('Main')
-	projects.addProject('Personal')
-
-	tasks.addTask('Do Odin', 'Main')
-	tasks.addTask('Do Lighthouse', 'Main')
-	tasks.addTask('Get busy', 'Personal')
-	tasks.addTask('Go crazy', 'Personal')
-}
 
 const app = (() => {
 
-	const state = {
-		currentProject: projects.projectList[0],
-		updateCurrentProject: (elementNumber) => state.currentProject = projects.projectList[elementNumber]
-	}
+  function addProjectTabListener () {
+    projectLayout.tabs.addEventListener('click', switchCurrentProject)
+  }
 
 	function switchCurrentProject (e) {
 		// check which project button was clicked
@@ -35,7 +24,7 @@ const app = (() => {
 				previousProjectTab.classList.remove('active-project-tab')
 				
 				// update state to new project
-				state.updateCurrentProject(elementNumber)
+				taskLayout.state.updateCurrentProject(elementNumber)
 				
 				// remove visible tasks
 				const taskElement = document.querySelector('.task-list')
@@ -45,178 +34,22 @@ const app = (() => {
 				e.target.classList.add('active-project-tab')
 				
 				// render tasks from new current project
-				renderCurrentTasks(state.currentProject)
+				taskLayout.renderCurrentTasks(taskLayout.state.currentProject)
 				
 			}
 		}
 	}
 
-	function renderProjectTabs () {
-		projects.projectList.forEach( ( project, index ) => {
-			const projectTab = document.createElement('button')
-			projectTab.classList.add('project-tab')
-			projectTab.dataset.project = project.name
-			index === 0 ? projectTab.classList.add('active-project-tab') : undefined
-
-			projectTab.textContent = project.name
-
-			projectTabs.appendChild(projectTab)
-		})
-		// create add new project button
-		const newProjectButton = document.createElement('button')
-		newProjectButton.classList.add('project-tab')
-		newProjectButton.classList.add('new-project')
-		newProjectButton.textContent = '➕'
-
-		projectTabs.appendChild(newProjectButton)
-	}
-
-	function buildTaskProperty (propertyName, property) {
-		const propertyContainer = document.createElement('div')
-		propertyContainer.classList.add('task-info')
-		propertyContainer.classList.add(`property-${u.camelToSnake(propertyName)}`)
-		
-		const propertyLabelContainer = document.createElement('div')
-		propertyLabelContainer.classList.add('task-property')
-		propertyContainer.appendChild(propertyLabelContainer)
-
-		const propertyLabel = document.createElement('p')
-		propertyLabel.classList.add('property-name')
-		propertyLabel.innerText = u.camelToHeadline(propertyName)
-		propertyLabelContainer.appendChild(propertyLabel)
-
-		const propertyValue = document.createElement('p')
-		propertyValue.classList.add('property-value')
-		propertyValue.innerText = property
-		propertyLabelContainer.appendChild(propertyValue)
-		
-		const editableTasks = ['parentProject', 'description', 'dueDate', 'notes']
-		if ( editableTasks.includes(propertyName)) {
-			const propertyActionContainer = document.createElement('div')
-			propertyActionContainer.classList.add('task-action')
-			const editButton = document.createElement('button')
-			editButton.innerText = '✏️'
-			propertyActionContainer.appendChild(editButton)
-			propertyContainer.appendChild(propertyActionContainer)
-		}
-		
-		return propertyContainer
-	}
-
-	function renderSingleTask (task) {
-
-		const taskElement = document.createElement('div')
-		taskElement.classList.add('task-element')
-		taskElement.classList.add('pop-out')
-		taskElement.dataset.id = task.id
-
-		const topContainer = document.createElement('div')
-		topContainer.classList.add('task-top-container')
-		
-		const taskText = document.createElement('p')
-		taskText.classList.add('task-title')
-		taskText.innerText = task.title
-
-		const expandButton = document.createElement('button')
-		expandButton.classList.add('task-expand')
-		expandButton.classList.add('animate-out')
-		expandButton.innerText = '🔍'
-
-
-		const taskDetails = document.createElement('div')
-		taskDetails.classList.add('task-details')
-		taskDetails.classList.add('hidden')
-		
-
-		taskElement.appendChild(topContainer)
-		topContainer.appendChild(taskText)
-		topContainer.appendChild(expandButton)
-		taskElement.appendChild(taskDetails)
-		taskDetails.appendChild(buildTaskProperty('parentProject', task.parentProject))
-		taskDetails.appendChild(buildTaskProperty('description', task.description))
-		taskDetails.appendChild(buildTaskProperty('dateCreated', task.dateCreated))
-		taskDetails.appendChild(buildTaskProperty('dueDate', task.dueDate))
-		taskDetails.appendChild(buildTaskProperty('priority', task.priority))
-		taskDetails.appendChild(buildTaskProperty('notes', task.notes))
-		taskDetails.appendChild(buildTaskProperty('checklist', task.checklist))
-
-		currentTasks.appendChild(taskElement)
-
-		expandButton.addEventListener('click', () => {
-			taskDetails.classList.toggle('hidden')
-		})
-	}
-
-	function createNewTask () {
-		// select button on dom and remove event listener
-		const newTaskButton = document.querySelector('.create-task')
-		newTaskButton.removeEventListener('click', createNewTask)
-		newTaskButton.innerText = ''
-		// create a form on the button
-		const inputForm = document.createElement('form')
-		newTaskButton.appendChild(inputForm)
-		const inputField = document.createElement('input')
-		inputField.type = 'text'
-		inputField.id = 'new-task-name'
-		inputField.placeholder = 'New Task Name...'
-		inputForm.appendChild(inputField)
-		inputField.focus()
-		// set event listener for input completion
-		inputForm.addEventListener('submit', (e) => {
-			e.preventDefault();
-			// create task
-			renderSingleTask(tasks.addTask(inputField.value, state.currentProject.name))
-			// remove new task button and create another at the bottom
-			newTaskButton.remove()
-			renderCreateTaskElement()
-		})
-		
-	}
-
-	function renderCreateTaskElement () {
-		const newTaskButton = document.createElement('button')
-		newTaskButton.classList.add('create-task')
-		newTaskButton.classList.add('animate-out')
-		newTaskButton.innerText = 'Create New Task'
-		newTaskButton.addEventListener('click', createNewTask)
-		currentTasks.appendChild(newTaskButton)
-	}
-
-	function renderCurrentTasks (currentProject) {
-		tasks.taskList.forEach( (task) => {
-			if (task.parentProject === currentProject.name) {
-				renderSingleTask(task)
-			}
-		})
-
-		renderCreateTaskElement()
-
-	}
-
-  function addProjectTabListener () {
-    const projectList = document.querySelector('.project-tabs')
-
-    projectList.addEventListener('click', switchCurrentProject)
-  }
-
-	// render project tabs
-	const projectTabs = document.createElement('div')
-	projectTabs.classList.add('project-tabs')
-	renderProjectTabs()
-
-	// render tasks 
-	const currentTasks = document.createElement('div')
-	currentTasks.classList.add('task-list')
-	renderCurrentTasks(state.currentProject)
-
 	// create layoutElement to pass to index.js
-	const layoutElement = document.createElement('div')
-	layoutElement.classList.add('layout')
+	const layoutElement = document.createElement('main')
+	layoutElement.classList.add('app')
 	// mount app onto layoutElement
-	layoutElement.appendChild(projectTabs)
-	layoutElement.appendChild(currentTasks)
+	layoutElement.appendChild(projectLayout.tabs)
+	layoutElement.appendChild(taskLayout.currentTasks)
 
-	return { layoutElement, addProjectTabListener }
+	addProjectTabListener()
+
+	return { layoutElement }
 })()
 
 

--- a/src/layouts/projects.js
+++ b/src/layouts/projects.js
@@ -1,0 +1,39 @@
+import { projects } from "../modules/createProject"
+
+// conditionally render default projects
+if (projects.projectList.length === 0) {
+	projects.addProject('Main')
+	projects.addProject('Personal')
+}
+
+const projectLayout = (() => {
+
+	function renderProjectTabs () {
+		projects.projectList.forEach( ( project, index ) => {
+			const projectTab = document.createElement('button')
+			projectTab.classList.add('project-tab')
+			projectTab.dataset.project = project.name
+			index === 0 ? projectTab.classList.add('active-project-tab') : undefined
+
+			projectTab.textContent = project.name
+
+			tabs.appendChild(projectTab)
+		})
+		// create add new project button
+		const newProjectButton = document.createElement('button')
+		newProjectButton.classList.add('project-tab')
+		newProjectButton.classList.add('new-project')
+		newProjectButton.textContent = '➕'
+
+		tabs.appendChild(newProjectButton)
+	}
+
+	// render project tabs
+	const tabs = document.createElement('div')
+	tabs.classList.add('project-tabs')
+	renderProjectTabs()
+
+  return { tabs }
+})()
+
+export { projectLayout }

--- a/src/layouts/tasks.js
+++ b/src/layouts/tasks.js
@@ -1,0 +1,151 @@
+import { projects } from "../modules/createProject"
+import { tasks } from "../modules/createTask"
+import { utility as u } from "../modules/utilityFunctions"
+
+// conditionally render default tasks
+if (tasks.taskList.length === 0) {
+  tasks.addTask('Do Odin', 'Main')
+	tasks.addTask('Do Lighthouse', 'Main')
+	tasks.addTask('Get busy', 'Personal')
+	tasks.addTask('Go crazy', 'Personal')
+}
+
+const taskLayout = ( () => {
+
+  const state = {
+		currentProject: projects.projectList[0],
+		updateCurrentProject: (elementNumber) => state.currentProject = projects.projectList[elementNumber]
+	}
+
+	function buildTaskProperty (propertyName, property) {
+		const propertyContainer = document.createElement('div')
+		propertyContainer.classList.add('task-info')
+		propertyContainer.classList.add(`property-${u.camelToSnake(propertyName)}`)
+		
+		const propertyLabelContainer = document.createElement('div')
+		propertyLabelContainer.classList.add('task-property')
+		propertyContainer.appendChild(propertyLabelContainer)
+
+		const propertyLabel = document.createElement('p')
+		propertyLabel.classList.add('property-name')
+		propertyLabel.innerText = u.camelToHeadline(propertyName)
+		propertyLabelContainer.appendChild(propertyLabel)
+
+		const propertyValue = document.createElement('p')
+		propertyValue.classList.add('property-value')
+		propertyValue.innerText = property
+		propertyLabelContainer.appendChild(propertyValue)
+		
+		const editableTasks = ['parentProject', 'description', 'dueDate', 'notes']
+		if ( editableTasks.includes(propertyName)) {
+			const propertyActionContainer = document.createElement('div')
+			propertyActionContainer.classList.add('task-action')
+			const editButton = document.createElement('button')
+			editButton.innerText = '✏️'
+			propertyActionContainer.appendChild(editButton)
+			propertyContainer.appendChild(propertyActionContainer)
+		}
+		
+		return propertyContainer
+	}
+
+  function renderSingleTask (task) {
+
+		const taskElement = document.createElement('div')
+		taskElement.classList.add('task-element')
+		taskElement.classList.add('pop-out')
+		taskElement.dataset.id = task.id
+
+		const topContainer = document.createElement('div')
+		topContainer.classList.add('task-top-container')
+		
+		const taskText = document.createElement('p')
+		taskText.classList.add('task-title')
+		taskText.innerText = task.title
+
+		const expandButton = document.createElement('button')
+		expandButton.classList.add('task-expand')
+		expandButton.classList.add('animate-out')
+		expandButton.innerText = '🔍'
+
+
+		const taskDetails = document.createElement('div')
+		taskDetails.classList.add('task-details')
+		taskDetails.classList.add('hidden')
+		
+
+		taskElement.appendChild(topContainer)
+		topContainer.appendChild(taskText)
+		topContainer.appendChild(expandButton)
+		taskElement.appendChild(taskDetails)
+		taskDetails.appendChild(buildTaskProperty('parentProject', task.parentProject))
+		taskDetails.appendChild(buildTaskProperty('description', task.description))
+		taskDetails.appendChild(buildTaskProperty('dateCreated', task.dateCreated))
+		taskDetails.appendChild(buildTaskProperty('dueDate', task.dueDate))
+		taskDetails.appendChild(buildTaskProperty('priority', task.priority))
+		taskDetails.appendChild(buildTaskProperty('notes', task.notes))
+		taskDetails.appendChild(buildTaskProperty('checklist', task.checklist))
+
+		currentTasks.appendChild(taskElement)
+
+		expandButton.addEventListener('click', () => {
+			taskDetails.classList.toggle('hidden')
+		})
+	}
+
+	function createNewTask () {
+		// select button on dom and remove event listener
+		const newTaskButton = document.querySelector('.create-task')
+		newTaskButton.removeEventListener('click', createNewTask)
+		newTaskButton.innerText = ''
+		// create a form on the button
+		const inputForm = document.createElement('form')
+		newTaskButton.appendChild(inputForm)
+		const inputField = document.createElement('input')
+		inputField.type = 'text'
+		inputField.id = 'new-task-name'
+		inputField.placeholder = 'New Task Name...'
+		inputForm.appendChild(inputField)
+		inputField.focus()
+		// set event listener for input completion
+		inputForm.addEventListener('submit', (e) => {
+			e.preventDefault();
+			// create task
+			renderSingleTask(tasks.addTask(inputField.value, state.currentProject.name))
+			// remove new task button and create another at the bottom
+			newTaskButton.remove()
+			renderCreateTaskElement()
+		})
+		
+	}
+
+	function renderCreateTaskElement () {
+		const newTaskButton = document.createElement('button')
+		newTaskButton.classList.add('create-task')
+		newTaskButton.classList.add('animate-out')
+		newTaskButton.innerText = 'Create New Task'
+		newTaskButton.addEventListener('click', createNewTask)
+		currentTasks.appendChild(newTaskButton)
+	}
+
+	function renderCurrentTasks (currentProject) {
+		tasks.taskList.forEach( (task) => {
+			if (task.parentProject === currentProject.name) {
+				renderSingleTask(task)
+			}
+		})
+
+		renderCreateTaskElement()
+
+	}
+
+	// render tasks 
+	const currentTasks = document.createElement('div')
+	currentTasks.classList.add('task-list')
+	renderCurrentTasks(state.currentProject)
+
+  return { currentTasks, state, renderCurrentTasks }
+
+} ) ()
+
+export { taskLayout }

--- a/src/style.css
+++ b/src/style.css
@@ -11,7 +11,7 @@ p {
   margin: 0;
 }
 
-.layout {
+.app {
   margin: 0 auto;
   width: min-content;
   display: grid;


### PR DESCRIPTION
Split the app module into two more modules representing the project tabs and the task area.

Interaction functions should be left in the app module for now.

State variable was moved into the tasksLayout module as that was the highest place in the module chain that it is needed.

Every interaction and button was tested before commit.